### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/javaobj.py
+++ b/javaobj.py
@@ -404,15 +404,14 @@ class JavaObjectConstants(object):
 
 class OpCodeDebug(object):
     # Type codes
-    OP_CODE = {getattr(JavaObjectConstants, key): key
-               for key in dir(JavaObjectConstants) if key.startswith("TC_")}
+    OP_CODE = dict((getattr(JavaObjectConstants, key), key)
+                   for key in dir(JavaObjectConstants) if key.startswith("TC_"))
 
-    TYPE = {getattr(JavaObjectConstants, key): key
-            for key in dir(JavaObjectConstants) if key.startswith("TYPE_")}
+    TYPE = dict((getattr(JavaObjectConstants, key), key)
+                for key in dir(JavaObjectConstants) if key.startswith("TYPE_"))
 
-    STREAM_CONSTANT = {getattr(JavaObjectConstants, key): key
-                       for key in dir(JavaObjectConstants)
-                       if key.startswith("SC_")}
+    STREAM_CONSTANT = dict((getattr(JavaObjectConstants, key), key)
+                           for key in dir(JavaObjectConstants) if key.startswith("SC_"))
 
     @staticmethod
     def op_id(op_id):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,pypy3
+envlist = py26,py27,py33,py34,py35,pypy,pypy3
 
 [testenv]
 commands = nosetests --with-coverage {posargs} tests


### PR DESCRIPTION
Allows javaobj-py3 (and by extension pyjks) to work under python 2.6. Passes all test cases for both javaobj-py3 and pyjks under python 2.6.9 on CentOS 7.