### PR TITLE
Add support for decoding CESU-8 encoded strings. 

### DIFF
--- a/javaobj.py
+++ b/javaobj.py
@@ -47,6 +47,12 @@ except ImportError:
     # Python 3+
     from io import BytesIO
 
+try:
+    import ftfy.bad_codecs
+    javacodec = "utf-8-var"
+except ImportError:
+    javacodec = "utf-8"
+
 # ------------------------------------------------------------------------------
 
 # Module version
@@ -641,7 +647,7 @@ class JavaObjectUnmarshaller(JavaObjectConstants):
         """
         (length,) = self._readStruct(">{0}".format(length_fmt))
         ba = self.object_stream.read(length)
-        return to_str(ba)
+        return to_str(ba.decode(javacodec))
 
     def do_classdesc(self, parent=None, ident=0):
         """


### PR DESCRIPTION
This works around java's broken utf-8 implementation.

You will need the https://github.com/LuminosoInsight/python-ftfy  module for the patch to have an effect.

The following code will now output a `😃` ( `\u0001f603` ), instead of raising a `UnicodeDecodeError`, or outputting `??????`.

```python
from __future__ import division, print_function
from binascii import a2b_hex
import javaobj

b = a2b_hex("ACED0005740006EDA0BDEDB883")
print(javaobj.loads(b))
```

The problem with the byte sequence `ED A0 BD ED B8 83` is that it decodes to `d83d de03` which are invalid codepoints, but is actually a valid `UTF-16` sequence, so you have to decode it twice, first utf-8, then utf-16, then you will end up with unicode character 0x1F603.
