### PR TITLE
Add support for java.lang.Bool, Integer and Long classes

### DIFF
--- a/javaobj/core.py
+++ b/javaobj/core.py
@@ -1709,6 +1709,35 @@ class DefaultObjectTransformer(object):
             # Lists have their content in there annotations
             self.extend(self.annotations[1:])
 
+    class JavaBool(JavaObject):
+        def __init__(self, unmarshaller):
+            JavaObject.__init__(self)
+            self.value = None
+            pass
+
+        def __str__(self):
+            return self.value.__str__()
+
+        def __repr__(self):
+            return self.value.__repr__()
+        
+        def __bool__(self):
+            return self.value
+
+    class JavaInt(JavaObject):
+        def __init__(self, unmarshaller):
+            self.value = None
+            JavaObject.__init__(self)
+
+        def __str__(self):
+            return self.value.__str__()
+
+        def __repr__(self):
+            return self.value.__repr__()
+        
+        def __int__(self):
+            return self.value
+
     class JavaMap(dict, JavaObject):
         """
         Python-Java dictionary/map bridge type
@@ -1955,6 +1984,8 @@ class DefaultObjectTransformer(object):
         "java.util.HashSet": JavaSet,
         "java.util.TreeSet": JavaTreeSet,
         "java.time.Ser": JavaTime,
+        "java.lang.Boolean": JavaBool,
+        "java.lang.Integer": JavaInt,
     }
 
     def create(self, classdesc, unmarshaller=None):

--- a/javaobj/core.py
+++ b/javaobj/core.py
@@ -1986,6 +1986,7 @@ class DefaultObjectTransformer(object):
         "java.time.Ser": JavaTime,
         "java.lang.Boolean": JavaBool,
         "java.lang.Integer": JavaInt,
+        "java.lang.Long": JavaInt,
     }
 
     def create(self, classdesc, unmarshaller=None):

--- a/javaobj/core.py
+++ b/javaobj/core.py
@@ -906,6 +906,9 @@ class JavaObjectUnmarshaller(JavaObjectConstants):
             and classdesc.flags & self.SC_WRITE_METHOD
             or classdesc.flags & self.SC_EXTERNALIZABLE
             and classdesc.flags & self.SC_BLOCK_DATA
+            or classdesc.superclass is not None
+            and classdesc.superclass.flags & self.SC_SERIALIZABLE
+            and classdesc.superclass.flags & self.SC_WRITE_METHOD
         ):
             # objectAnnotation
             log_debug(


### PR DESCRIPTION
This PR adds support for instances of
- java.lang.Bool
- java.lang.Integer
- java.lang.Long

Test cases created with:
```
import java.io.FileOutputStream;
import java.io.ObjectOutputStream;
import java.util.HashMap;

public class Creator {
    public static void main(String[] args)
    throws Exception {
        HashMap hm1 = new HashMap();
        hm1.put("key1", "value1");
        hm1.put("key2", "value2");
        hm1.put("int", 9);
        hm1.put("ing2", new Integer(10));
        hm1.put("bool", true);
        hm1.put("bool2", new Boolean(true));
        FileOutputStream fs = new FileOutputStream("hashmap-1.ser");
        ObjectOutputStream os = new ObjectOutputStream(fs);
        os.writeObject(hm1);
        os.close();

        HashMap hm2 = new HashMap();
        hm2.put("key1", hm1);
        fs = new FileOutputStream("hashmap-2.ser");
        os = new ObjectOutputStream(fs);
        os.writeObject(hm2);
        os.close();
    }
}
```

Tested with:
```
#!/usr/bin/python3
  
import sys
import logging

logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)

import javaobj

#filename = 'creator/hashmap-1.ser'
filename = 'creator/hashmap-2.ser'
with open(filename, 'rb') as fd:
    jobj = fd.read()

pobj = javaobj.loads(jobj)
print(pobj)
```