### PR TITLE
Marshal JavaByteArrays

### DIFF
--- a/javaobj/v1/marshaller.py
+++ b/javaobj/v1/marshaller.py
@@ -141,6 +141,9 @@ class JavaObjectMarshaller:
         if isinstance(obj, JavaArray):
             # Deserialized Java array
             self.write_array(obj)
+        elif isinstance(obj, JavaByteArray):
+            # Deserialized Java byte array
+            self.write_array(obj)
         elif isinstance(obj, JavaEnum):
             # Deserialized Java Enum
             self.write_enum(obj)


### PR DESCRIPTION
Java Byte arrays will now be marshalled correctly, partially closes #52 