### PR TITLE
fix path to tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     license_file="LICENSE",
     keywords="python java marshalling serialization",
     packages=["javaobj", "javaobj.v1", "javaobj.v2"],
-    test_suite="tests.tests",
+    test_suite="tests.test_v1",
     install_requires=[
         'enum34;python_version<="3.4"',
         'typing;python_version<="3.4"',


### PR DESCRIPTION
6f361ebbac49c281c3e44f7c5c039637a5cf3390 renamed _tests/tests.py_ but did not change the path in _setup.py_.